### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/PengleiYu/screeps-ai/security/code-scanning/1](https://github.com/PengleiYu/screeps-ai/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code, installs dependencies, builds, and runs tests, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow (applies to all jobs), setting `contents: read`. This should be added after the `name` field and before the `on` field (i.e., after line 4 and before line 6).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for the Node.js CI pipeline to restrict repository content access to read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->